### PR TITLE
Fix astropy tests

### DIFF
--- a/astropy/io/fits/tiled_compression/tiled_compression.py
+++ b/astropy/io/fits/tiled_compression/tiled_compression.py
@@ -446,13 +446,17 @@ def compress_hdu(hdu):
     if hdu._header["ZCMPTYPE"] == "PLIO_1":
         table["COMPRESSED_DATA"][:, 0] //= 2
 
-    compressed_bytes = b"".join(compressed_bytes)
-
     # For PLIO_1, it looks like the compressed data is byteswapped
     if hdu._header["ZCMPTYPE"] == "PLIO_1":
-        compressed_bytes = (
-            np.frombuffer(compressed_bytes, dtype="<i2").astype(">i2").tobytes()
-        )
+        for irow in range(len(compressed_bytes)):
+            if not gzip_fallback[irow]:
+                compressed_bytes[irow] = (
+                    np.frombuffer(compressed_bytes[irow], dtype="<i2")
+                    .astype(">i2")
+                    .tobytes()
+                )
+
+    compressed_bytes = b"".join(compressed_bytes)
 
     table_bytes = table.tobytes()
 

--- a/astropy/io/fits/tiled_compression/tiled_compression.py
+++ b/astropy/io/fits/tiled_compression/tiled_compression.py
@@ -253,6 +253,9 @@ def decompress_hdu(hdu):
 
     quantize = "ZSCALE" in hdu.compressed_data.dtype.names
 
+    if len(hdu.compressed_data) == 0:
+        return None
+
     istart = np.zeros(data.ndim, dtype=int)
     for irow, row in enumerate(hdu.compressed_data):
 
@@ -352,6 +355,9 @@ def compress_hdu(hdu):
 
     while True:
 
+        if hdu.data is None:
+            break
+
         # In the following, we don't need to special case tiles near the edge
         # as Numpy will automatically ignore parts of the slices that are out
         # of bounds.
@@ -427,7 +433,7 @@ def compress_hdu(hdu):
     for irow, cbytes in enumerate(compressed_bytes):
         table["COMPRESSED_DATA"][irow, 0] = len(cbytes)
 
-    table["COMPRESSED_DATA"][0, 1] = 0
+    table["COMPRESSED_DATA"][:1, 1] = 0
     table["COMPRESSED_DATA"][1:, 1] = np.cumsum(table["COMPRESSED_DATA"][:-1, 0])
 
     for irow in range(len(compressed_bytes)):


### PR DESCRIPTION
This fixes three of the four failing tests - the last one is:

```
    def test_comp_image_hcompress_image_stack(self):
        """
        Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/171
    
        Tests that data containing more than two dimensions can be
        compressed with HCOMPRESS_1 so long as the user-supplied tile size can
        be flattened to two dimensions.
        """
    
        cube = np.arange(300, dtype=np.float32).reshape(3, 10, 10)
        hdu = fits.CompImageHDU(
            data=cube,
            name="SCI",
            compression_type="HCOMPRESS_1",
            quantize_level=16,
            tile_size=[5, 5, 1],
        )
        hdu.writeto(self.temp("test.fits"))
    
        with fits.open(self.temp("test.fits")) as hdul:
            # HCOMPRESSed images are allowed to deviate from the original by
            # about 1/quantize_level of the RMS in each tile.
>           assert np.abs(hdul["SCI"].data - cube).max() < 1.0 / 15.0
E           AssertionError: assert 0.12690735 < (1.0 / 15.0)
E            +  where 0.12690735 = <built-in method max of numpy.ndarray object at 0x11054c390>()
E            +    where <built-in method max of numpy.ndarray object at 0x11054c390> = array([[[0.        , 0.04835784, 0.03432894, 0.01402903, 0.06238699,\n         0.02029991, 0.10298681, 0.07641602, 0.00...7, 0.01602173, 0.06439209,\n         0.11276245, 0.03005981, 0.07843018, 0.00427246, 0.0440979 ]]],\n      dtype=float32).max
E            +      where array([[[0.        , 0.04835784, 0.03432894, 0.01402903, 0.06238699,\n         0.02029991, 0.10298681, 0.07641602, 0.00...7, 0.01602173, 0.06439209,\n         0.11276245, 0.03005981, 0.07843018, 0.00427246, 0.0440979 ]]],\n      dtype=float32) = <ufunc 'absolute'>((array([[[  0.       ,   1.0483578,   1.9656711,   3.014029 ,\n           4.062387 ,   4.9797   ,   5.897013 ,   7.07641...02  ,\n         294.0644   , 295.11276  , 296.03006  , 297.07843  ,\n         297.99573  , 299.0441   ]]], dtype=float32) - array([[[  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.],\n        [ 10.,  11.,  12.,  13.,  14.,  15.,  16..., 286., 287., 288., 289.],\n        [290., 291., 292., 293., 294., 295., 296., 297., 298., 299.]]],\n      dtype=float32)))
E            +        where <ufunc 'absolute'> = np.abs
E            +        and   array([[[  0.       ,   1.0483578,   1.9656711,   3.014029 ,\n           4.062387 ,   4.9797   ,   5.897013 ,   7.07641...02  ,\n         294.0644   , 295.11276  , 296.03006  , 297.07843  ,\n         297.99573  , 299.0441   ]]], dtype=float32) = <astropy.io.fits.hdu.compressed.CompImageHDU object at 0x168aaa800>.data
```

I'll need to check at the C level what the HCOMPRESS and quantization functions are getting called with to see if any of the parameters differ.